### PR TITLE
Using perstistent term instead of ETS 

### DIFF
--- a/src/wgconfig_storage.erl
+++ b/src/wgconfig_storage.erl
@@ -81,8 +81,27 @@ get_config_files() ->
     gen_server:call(?MODULE, get_config_files).
 
 
+-spec clear_persistent_term() -> ok.
+clear_persistent_term() ->
+    {CompositeKeys, _Values} = lists:unzip(persistent_term:get()),
+
+    lists:foreach(
+        fun
+            ({?MODULE, SectionName, Key}) ->
+                persistent_term:erase({?MODULE, SectionName, Key});
+
+            (_) ->
+                nothing
+        end,
+        CompositeKeys
+    ),
+
+    ok.
+
+
 -spec stop() -> ok.
 stop() ->
+    clear_persistent_term(),
     gen_server:cast(?MODULE, stop),
     ok.
 

--- a/test/wgconfig_storage_tests.erl
+++ b/test/wgconfig_storage_tests.erl
@@ -31,7 +31,7 @@ one_config_test() ->
     ?assertEqual({error,not_found},
                  wgconfig_storage:get(<<"some_section">>, <<"port">>)),
 
-    wgconfig_storage:stop(),
+    wgconfig_storage:stop(), %cleanup storage
     ok.
 
 
@@ -73,7 +73,7 @@ two_configs_test() ->
     ?assertEqual({error,not_found},
                  wgconfig_storage:get(<<"some_section">>, <<"port">>)),
 
-    wgconfig_storage:stop(),
+    wgconfig_storage:stop(), %cleanup storage
     ok.
 
 
@@ -100,7 +100,7 @@ names_test() ->
     ?assertEqual({error,not_found},
                  wgconfig_storage:get(some_section, port)),
 
-    wgconfig_storage:stop(),
+    wgconfig_storage:stop(), %cleanup storage
     ok.
 
 
@@ -121,7 +121,7 @@ set_test() ->
     wgconfig_storage:set(<<"http_client">>, <<"retry_time">>, <<"5000">>),
     ?assertEqual({ok, <<"5000">>}, wgconfig_storage:get(http_client, "retry_time")),
 
-    wgconfig_storage:stop(),
+    wgconfig_storage:stop(), %cleanup storage
     ok.
 
 
@@ -148,7 +148,8 @@ list_sections_test() ->
     ok.
 
 list_keys_test() ->
-    application:stop(wgconfig),                 %cleanup storage
+    wgconfig_storage:stop(), %cleanup storage
+    application:stop(wgconfig),
     setup(),
     ?assertEqual([], wgconfig_storage:list_keys(wasd)),
     ?assertEqual([], wgconfig_storage:list_keys(database)),


### PR DESCRIPTION
Perstistent term storage is similar to ets in that it provides a storage for Erlang terms that can be accessed in constant time, but with the difference that persistent_term has been highly optimized for reading terms at the expense of writing and updating terms. ([Erlang docs](http://erlang.org/doc/man/persistent_term.html))